### PR TITLE
PXB-2243 undo tablespaces are corrupted if undo truncation happens between full backup and incremental

### DIFF
--- a/storage/innobase/xtrabackup/test/bootstrap.sh
+++ b/storage/innobase/xtrabackup/test/bootstrap.sh
@@ -36,12 +36,12 @@ fi
 case "$1" in
     innodb80)
         url="https://dev.mysql.com/get/Downloads/MySQL-8.0"
-        tarball="mysql-8.0.20-linux-glibc2.12-${arch}.tar.xz"
+        tarball="mysql-8.0.21-linux-glibc2.12-${arch}.tar.xz"
         ;;
 
     xtradb80)
-        url="https://www.percona.com/downloads/Percona-Server-8.0/Percona-Server-8.0.18-9/binary/tarball"
-        tarball="Percona-Server-8.0.18-9-Linux.${arch}.glibc2.12.tar.gz"
+        url="https://www.percona.com/downloads/Percona-Server-8.0/Percona-Server-8.0.20-11/binary/tarball"
+        tarball="Percona-Server-8.0.20-11-Linux.${arch}.glibc2.12.tar.gz"
         ;;
 
     *)


### PR DESCRIPTION
Problem:
 --------
 With 8.0.21, undo tablespace truncations are done differently. Check upstream WL#11819: Support ACID Undo DDL.
 In 8.0.20, there is explicit flushing of all undo tablespace pages as part of undo tablespaces.
 From 8.0.21, for undo tablespace truncation, the explicit flushing of undo tablespace pages is removed
 and all truncate changes are redo logged.

PXB with 8.0.20, relied on the explicit flushing. all the modified pages are in the undo delta files. By applying the pages from delta file,
 undo tablespace tablespace_id changes to the desired/final space_id.

From 8.0.21, since the modified pages during truncate are not flushed, the delta files are empty. This means, undo tablespace in backup directory
 will continue to have old space_id.

For applying changes on the new undo tablespaces (with new space_id), redo has to find the tablespace with new space_id.
 Note that PXB doesn't really apply MLOG_FILE_CREATE or DELETE records. It just parses them only. So redo log from undo truncation couldn't be applied.
 Thus undo tablespces after incremental remains with the old space_id.

Next server startup, any operation on undo tablespaces detects the mismatch in space_id and aborts the operation.

Fix:
----
As part of incremental apply, we now detect the space_id mismatch of undo tablespaces.
 This is already done for regular IBD files. When space_id mismatch is detected, we rename the undo tablespace in backup directory to a temporary one
 and create the undo tablespace with newer space_id. The newer space_id is from incremental undo meta file.

Since the undo with newer space_id is now avaialbe, all redo from undo truncation is  applied.