### PR TITLE
  PXB-2925 Redo start_lsn doesn't match with redo file start LSN

### DIFF
--- a/storage/innobase/include/log0files_dict.h
+++ b/storage/innobase/include/log0files_dict.h
@@ -144,6 +144,14 @@ class Log_files_dict {
   @param[in]  file_id         id of the log file */
   void set_incomplete(Log_file_id file_id);
 
+#ifdef XTRABACKUP
+  /** Changes start_lsn of the file. Updates m_end_lsn accordingly.
+  @param[in]  file_id         id of the log file
+  @param[in]  start_lsn       new_start_lsn
+  */
+  void set_lsn(Log_file_id file_id, lsn_t start_lsn);
+#endif
+
   /** Changes size of the file. Updates m_end_lsn accordingly.
   @param[in]  file_id         id of the log file
   @param[in]  new_size        new size (expressed in bytes) */

--- a/storage/innobase/include/log0files_io.h
+++ b/storage/innobase/include/log0files_io.h
@@ -562,6 +562,20 @@ inline uint32_t log_block_convert_lsn_to_hdr_no(lsn_t lsn) {
          static_cast<uint32_t>(lsn / OS_FILE_LOG_BLOCK_SIZE % LOG_BLOCK_MAX_NO);
 }
 
+/* convert hdr to LSN
+@param[in] header log_block_number
+@param[in] start_lsn the current start_LSN set in system
+@return LSN number */
+inline lsn_t log_block_convert_hdr_to_lsn_no(uint32_t header, lsn_t start_lsn) {
+  ut_ad(header <= LOG_BLOCK_MAX_NO);
+
+  uint32_t round_off =
+      static_cast<uint32_t>(start_lsn / OS_FILE_LOG_BLOCK_SIZE /
+                            LOG_BLOCK_MAX_NO) +
+      1;
+  return header * OS_FILE_LOG_BLOCK_SIZE * round_off - OS_FILE_LOG_BLOCK_SIZE;
+}
+
 /** Calculates the checksum for a log block.
 @param[in]	log_block	log block
 @return checksum */

--- a/storage/innobase/log/log0files_dict.cc
+++ b/storage/innobase/log/log0files_dict.cc
@@ -148,6 +148,22 @@ void Log_files_dict::set_incomplete(Log_file_id file_id) {
   it->second.m_full = false;
 }
 
+#ifdef XTRABACKUP
+void Log_files_dict::set_lsn(Log_file_id file_id, lsn_t start_lsn) {
+  const auto it = m_files_by_id.find(file_id);
+  ut_a(it != m_files_by_id.end());
+  auto &meta_info = it->second;
+
+  meta_info.m_start_lsn =
+      ut_uint64_align_down(start_lsn, OS_FILE_LOG_BLOCK_SIZE);
+  ut_a(meta_info.m_start_lsn > 0);
+
+  const bool success = log_file_compute_end_lsn(
+      meta_info.m_start_lsn, meta_info.m_size_in_bytes, meta_info.m_end_lsn);
+  ut_a(success);
+}
+#endif
+
 void Log_files_dict::set_size(Log_file_id file_id, os_offset_t new_size) {
   const auto it = m_files_by_id.find(file_id);
   ut_a(it != m_files_by_id.end());

--- a/storage/innobase/xtrabackup/src/redo_log.cc
+++ b/storage/innobase/xtrabackup/src/redo_log.cc
@@ -81,8 +81,11 @@ bool Redo_Log_Reader::find_start_checkpoint_lsn() {
     log_scanned_lsn = checkpoint.m_checkpoint_lsn;
     checkpoint_lsn_start = checkpoint.m_checkpoint_lsn;
 
+    debug_sync_point("xbredo_wait_now");
+
     /* Copy the header into log_hdr_buf */
     file_handle.read(0, LOG_FILE_HDR_SIZE, log_hdr_buf);
+
   } else {
     const auto logfile0 = log_sys->m_files.file(0);
     auto file_handle = logfile0->open(Log_file_access_mode::READ_ONLY);
@@ -100,9 +103,13 @@ bool Redo_Log_Reader::find_start_checkpoint_lsn() {
     checkpoint_lsn_start = chkp_header.m_checkpoint_lsn;
     checkpoint_offset_start = chkp_header.m_checkpoint_offset;
 
+    debug_sync_point("xbredo_wait_now");
+
     /* Copy the header into log_hdr_buf */
     file_handle.read(0, LOG_FILE_HDR_SIZE, log_hdr_buf);
   }
+  /* update the headers to store the current checkpoint LSN */
+  update_log_temp_checkpoint(log_hdr_buf, checkpoint_lsn_start);
 
   return (true);
 }

--- a/storage/innobase/xtrabackup/src/redo_log.h
+++ b/storage/innobase/xtrabackup/src/redo_log.h
@@ -246,8 +246,9 @@ class Archived_Redo_Log_Monitor {
   /** Get first log block checksum from the archived redo log. */
   uint32_t get_first_log_block_checksum() const;
 
-  /** Read archived log until the given log block. */
-  void skip_for_block(lsn_t lsn, const byte *redo_buf);
+  /** Read archived log until the given log block.
+   @return true if no error occured or false if error occured */
+  bool skip_for_block(lsn_t lsn, const byte *redo_buf);
 
  private:
   /** Parse the value of innodb_redo_log_archive_dirs. */
@@ -327,8 +328,9 @@ class Redo_Log_Data_Manager {
   bool copy_once(bool is_last, bool *finished);
 
   /** Compare archived log block number and lsn with the current lsn
-      and seek archived log if needed. */
-  void track_archived_log(lsn_t start_lsn, const byte *buf, size_t len);
+      and seek archived log if needed.
+     @return true if no error occured or false if error occured */
+  bool track_archived_log(lsn_t start_lsn, const byte *buf, size_t len);
 
   /** copying thread. */
   IB_thread thread;

--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -5039,10 +5039,8 @@ static void xtrabackup_stats_func(int argc, char **argv) {
 
 /* ================= prepare ================= */
 
-static void update_log_temp_checkpoint(byte *buf, lsn_t lsn) {
+void update_log_temp_checkpoint(byte *buf, lsn_t lsn) {
   /* Overwrite the both checkpoint area. */
-
-
   mach_write_to_8(buf + LOG_CHECKPOINT_1 + LOG_CHECKPOINT_LSN, lsn);
   mach_write_to_8(buf + LOG_CHECKPOINT_2 + LOG_CHECKPOINT_LSN, lsn);
 

--- a/storage/innobase/xtrabackup/src/xtrabackup.h
+++ b/storage/innobase/xtrabackup/src/xtrabackup.h
@@ -331,4 +331,9 @@ bool xb_process_datadir(const char *path,   /*!<in: datadir path */
                         void *data); /*!<in: additional argument for
                                      callback */
 
+/* update the checkpoint and checksum in both log header buffer
+@param[in/out]	buf		log header buffer
+@param[in]	lsn		lsn to update */
+void update_log_temp_checkpoint(byte *buf, lsn_t lsn);
+
 #endif /* XB_XTRABACKUP_H */

--- a/storage/innobase/xtrabackup/test/suites/keyring/pxb-1942.sh
+++ b/storage/innobase/xtrabackup/test/suites/keyring/pxb-1942.sh
@@ -54,7 +54,9 @@ function run_test() {
 
   if ! grep -q "Archived redo log has caught up" $topdir/backup.log ; then
       if ! grep -q "Switched to archived redo log starting with LSN" $topdir/backup.log ; then
+	if ! grep -q "Finished reading archive" $topdir/bakup.log; then
 	  die "Archived logs were not used"
+	fi
       fi
   fi
 

--- a/storage/innobase/xtrabackup/test/t/undo_tablespaces.sh
+++ b/storage/innobase/xtrabackup/test/t/undo_tablespaces.sh
@@ -65,15 +65,14 @@ xtrabackup --backup --target-dir=$topdir/inc --incremental-basedir=$topdir/backu
 kill -SIGKILL $job_master
 stop_server
 
+xtrabackup --prepare --apply-log-only --target-dir=$topdir/backup
+xtrabackup --prepare --target-dir=$topdir/backup --incremental-dir=$topdir/inc
+
 rm -rf $MYSQLD_DATADIR/*
 rm -rf $undo_directory/*
 rm -rf $undo_directory_ext/*
 
-xtrabackup --prepare --apply-log-only --target-dir=$topdir/backup
-xtrabackup --prepare --target-dir=$topdir/backup --incremental-dir=$topdir/inc
-
 xtrabackup --copy-back --target-dir=$topdir/backup
-
 
 for file in $undo_directory/undo1.ibu $undo_directory/undo2.ibu \
         $undo_directory/undo3.ibu $undo_directory/undo4.ibu ; do


### PR DESCRIPTION
  PXB-2925 Redo start_lsn doesn't match with redo file start LSN
    https://jira.percona.com/browse/PXB-2925

    Problem:
    During the prepare phase start_lsn of redo file does not match with first lsn in redo
    file

    Analysis:
    During backup phase, PXB sequentially reads the checkpoint LSN and then copies the
    checkpoint header. PXB copies the redo logs start from this checkpoint
    LSN. During the prepare phase it sets the start LSN from the checkpoint header.

    The problem comes if the server does a checkpoint after reading of checkpoint LSN
    and before copying the checkpoint header. The redo file copied by PXB would have LSN
    starting from and checkpoint LSN but the LSN in checkpoint header would be different.
    Since prepare calculates start_lsn from checkpoint header, PXB could set a wrong start
    LSN which would not match the first lsn of the redo file.

    Fix:
    To fix backup, PXB now updates the checkpoint header to have the correct
    checkpoint LSN.
    To prepare old backup, PXB finds the correct start LSN in redo file and then
    update the start_lsn of redo file.
