### PR TITLE
PXB-2977 Validate decompress paths (qpress, zstd)

### DIFF
--- a/storage/innobase/xtrabackup/src/backup_copy.cc
+++ b/storage/innobase/xtrabackup/src/backup_copy.cc
@@ -2222,7 +2222,6 @@ decrypt_decompress_file(const char *filepath, uint thread_n)
 	}
 	cmd << " >\"$" << output_file.str().c_str() << "\"";
 
- 	free(dest_filepath);
 
  	if (needs_action) {
 
@@ -2248,6 +2247,7 @@ decrypt_decompress_file(const char *filepath, uint thread_n)
 	 		}
 	 	}
 	 }
+ 	free(dest_filepath);
 	unsetenv(input_file.str().c_str());
 	unsetenv(output_file.str().c_str());
 

--- a/storage/innobase/xtrabackup/src/backup_copy.cc
+++ b/storage/innobase/xtrabackup/src/backup_copy.cc
@@ -2177,16 +2177,15 @@ decrypt_decompress_file(const char *filepath, uint thread_n)
 	std::stringstream cmd, message,input_file,output_file;
 	bool needs_action = false;
 
-        char *dest_filepath = strdup(filepath);
-	input_file << "xbinputfile" << thread_n;
+	char *dest_filepath = strdup(filepath);
+	input_file << "PXBINFILE" << thread_n;
 	if (setenv(input_file.str().c_str(), filepath, 1) == -1) {
 		int errsv = errno;
 		msg_ts("[%02u] Can not set env %s: to %s got error %d\n",
 			thread_n, input_file.str().c_str(), filepath, errsv);
 		return false;
 	}
-	/*cmd will be cat $xbinputfile1 */
-	cmd << "cat \"$" << input_file.str().c_str() << "\"";
+        cmd << "cat \"$" << input_file.str().c_str() << "\"";
 
  	if (ends_with(filepath, ".xbcrypt") && opt_decrypt) {
  		cmd << " | xbcrypt --decrypt --encrypt-algo="
@@ -2213,9 +2212,8 @@ decrypt_decompress_file(const char *filepath, uint thread_n)
  		needs_action = true;
  	}
 	message << " " << filepath;
-        output_file << "xboutputfile" << thread_n;
-
-	if (setenv(output_file.str().c_str(), dest_filepath, 1) == -1) {
+        output_file << "PXBOUTFILE" << thread_n;
+        if (setenv(output_file.str().c_str(), dest_filepath, 1) == -1) {
 		int errsv = errno;
 		msg_ts("[%02u] Can not set env %s: to %s got error %d\n",
 				thread_n, output_file.str().c_str(),
@@ -2230,7 +2228,8 @@ decrypt_decompress_file(const char *filepath, uint thread_n)
 
 		msg_ts("[%02u] %s\n", thread_n, message.str().c_str());
 
-	 	if (system(cmd.str().c_str()) != 0) {
+		/* cat $XBINFILE|xbcrtyp --decrpyt|qpress -dio > $XBOUTFILE */
+		if (system(cmd.str().c_str()) != 0) {
 	 		return(false);
 	 	}
 

--- a/storage/innobase/xtrabackup/src/backup_copy.cc
+++ b/storage/innobase/xtrabackup/src/backup_copy.cc
@@ -2234,6 +2234,10 @@ decrypt_decompress_file(const char *filepath, uint thread_n)
 			msg_ts("[%02u] Can not run %s on %s got error %d\n",
 					thread_n, cmd.str().c_str(),filepath,
 					ret_status);
+			msg_ts("[%02u] Enviorment variable are %s and %s \n",
+					thread_n, getenv(input_file.str().c_str()),
+					getenv(output_file.str().c_str()));
+
 			return false;
                 }
 

--- a/storage/innobase/xtrabackup/src/backup_copy.cc
+++ b/storage/innobase/xtrabackup/src/backup_copy.cc
@@ -2176,10 +2176,17 @@ decrypt_decompress_file(const char *filepath, uint thread_n)
 {
 	std::stringstream cmd, message,input_file,output_file;
 	bool needs_action = false;
+	int env_error;
 
         char *dest_filepath = strdup(filepath);
 	input_file << "xbinputfile" << thread_n;
-	setenv(input_file.str().c_str(), filepath, 1);
+	env_error = setenv(input_file.str().c_str(), filepath, 1);
+	if (env_error != 0) {
+		msg("Can not set env %s: got error %d\n",
+				input_file.str().c_str(), env_error);
+		return false;
+	}
+
 	cmd << "cat \"$" << input_file.str().c_str() << "\"";
 
  	if (ends_with(filepath, ".xbcrypt") && opt_decrypt) {
@@ -2209,7 +2216,12 @@ decrypt_decompress_file(const char *filepath, uint thread_n)
 	message << " " << filepath;
 
         output_file << "xboutputfile" << thread_n;
-	setenv(output_file.str().c_str(), dest_filepath, 1);
+	env_error = setenv(output_file.str().c_str(), dest_filepath, 1);
+	if (env_error != 0) {
+		msg("Can not set env %s: got error %d\n",
+				output_file.str().c_str(), env_error);
+		return false;
+	}
 	cmd << " >\"$" << output_file.str().c_str() << "\"";
 
  	free(dest_filepath);
@@ -2229,6 +2241,8 @@ decrypt_decompress_file(const char *filepath, uint thread_n)
 	 		}
 	 	}
 	 }
+	unsetenv(input_file.str().c_str());
+	unsetenv(output_file.str().c_str());
 
  	return(true);
 }

--- a/storage/innobase/xtrabackup/src/backup_copy.cc
+++ b/storage/innobase/xtrabackup/src/backup_copy.cc
@@ -2178,7 +2178,7 @@ decrypt_decompress_file(const char *filepath, uint thread_n)
 	bool needs_action = false;
 
 	char *dest_filepath = strdup(filepath);
-	input_file << "PXBINFILE" << thread_n;
+	input_file << "PXBINFILE" << thread_n << "p" << getpid();
 	if (setenv(input_file.str().c_str(), filepath, 1) == -1) {
 		int errsv = errno;
 		msg_ts("[%02u] Can not set env %s: to %s got error %d\n",
@@ -2212,7 +2212,7 @@ decrypt_decompress_file(const char *filepath, uint thread_n)
  		needs_action = true;
  	}
 	message << " " << filepath;
-        output_file << "PXBOUTFILE" << thread_n;
+        output_file << "PXBOUTFILE" << thread_n << "p" << getpid();
         if (setenv(output_file.str().c_str(), dest_filepath, 1) == -1) {
 		int errsv = errno;
 		msg_ts("[%02u] Can not set env %s: to %s got error %d\n",

--- a/storage/innobase/xtrabackup/src/backup_copy.cc
+++ b/storage/innobase/xtrabackup/src/backup_copy.cc
@@ -2174,7 +2174,7 @@ cleanup:
 bool
 decrypt_decompress_file(const char *filepath, uint thread_n)
 {
-	std::stringstream cmd, message,input_file,output_file;
+	std::stringstream cmd, message, input_file, output_file;
 	bool needs_action = false;
 
 	char *dest_filepath = strdup(filepath);
@@ -2228,8 +2228,8 @@ decrypt_decompress_file(const char *filepath, uint thread_n)
 
 		msg_ts("[%02u] %s\n", thread_n, message.str().c_str());
 
-		/* cat $XBINFILE|xbcrtyp --decrpyt|qpress -dio > $XBOUTFILE */
-		if (system(cmd.str().c_str()) != 0) {
+                /* cat $XBINFILE|xbcrypt --decrpyt|qpress -dio > $XBOUTFILE */
+                if (system(cmd.str().c_str()) != 0) {
 	 		return(false);
 	 	}
 

--- a/storage/innobase/xtrabackup/src/backup_copy.cc
+++ b/storage/innobase/xtrabackup/src/backup_copy.cc
@@ -2185,7 +2185,7 @@ decrypt_decompress_file(const char *filepath, uint thread_n)
 			thread_n, input_file.str().c_str(), filepath, errsv);
 		return false;
 	}
-
+	/*cmd will be cat $xbinputfile1 */
 	cmd << "cat \"$" << input_file.str().c_str() << "\"";
 
  	if (ends_with(filepath, ".xbcrypt") && opt_decrypt) {

--- a/storage/innobase/xtrabackup/src/backup_copy.cc
+++ b/storage/innobase/xtrabackup/src/backup_copy.cc
@@ -2229,11 +2229,15 @@ decrypt_decompress_file(const char *filepath, uint thread_n)
 		msg_ts("[%02u] %s\n", thread_n, message.str().c_str());
 
                 /* cat $XBINFILE|xbcrypt --decrpyt|qpress -dio > $XBOUTFILE */
-                if (system(cmd.str().c_str()) != 0) {
-	 		return(false);
-	 	}
+                int ret_status = system(cmd.str().c_str());
+                if (ret_status != 0) {
+			msg_ts("[%02u] Can not run %s on %s got error %d\n",
+					thread_n, cmd.str().c_str(),filepath,
+					ret_status);
+			return false;
+                }
 
-	 	if (opt_remove_original) {
+                if (opt_remove_original) {
 	 		msg_ts("[%02u] removing %s\n", thread_n, filepath);
 	 		if (my_delete(filepath, MYF(MY_WME)) != 0) {
 	 			return(false);

--- a/storage/innobase/xtrabackup/src/backup_copy.cc
+++ b/storage/innobase/xtrabackup/src/backup_copy.cc
@@ -2176,14 +2176,13 @@ decrypt_decompress_file(const char *filepath, uint thread_n)
 {
 	std::stringstream cmd, message,input_file,output_file;
 	bool needs_action = false;
-	int env_error;
 
         char *dest_filepath = strdup(filepath);
 	input_file << "xbinputfile" << thread_n;
-	env_error = setenv(input_file.str().c_str(), filepath, 1);
-	if (env_error != 0) {
-		msg("Can not set env %s: got error %d\n",
-				input_file.str().c_str(), env_error);
+	if (setenv(input_file.str().c_str(), filepath, 1) == -1) {
+		int errsv = errno;
+		msg_ts("[%02u] Can not set env %s: to %s got error %d\n",
+			thread_n, input_file.str().c_str(), filepath, errsv);
 		return false;
 	}
 
@@ -2214,12 +2213,13 @@ decrypt_decompress_file(const char *filepath, uint thread_n)
  		needs_action = true;
  	}
 	message << " " << filepath;
-
         output_file << "xboutputfile" << thread_n;
-	env_error = setenv(output_file.str().c_str(), dest_filepath, 1);
-	if (env_error != 0) {
-		msg("Can not set env %s: got error %d\n",
-				output_file.str().c_str(), env_error);
+
+	if (setenv(output_file.str().c_str(), dest_filepath, 1) == -1) {
+		int errsv = errno;
+		msg_ts("[%02u] Can not set env %s: to %s got error %d\n",
+				thread_n, output_file.str().c_str(),
+				dest_filepath, errsv);
 		return false;
 	}
 	cmd << " >\"$" << output_file.str().c_str() << "\"";

--- a/storage/innobase/xtrabackup/test/t/xb_decompress_file_validation.sh
+++ b/storage/innobase/xtrabackup/test/t/xb_decompress_file_validation.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+. inc/common.sh
+
+start_server
+
+vlog "case#1 backup with qpress and compression"
+
+xtrabackup --backup --target-dir=$topdir/backup --compress --encrypt=AES256 --encrypt-key=percona_xtrabackup_is_awesome___
+
+echo "echo secret_text_not_to_be_printed" > $topdir/backup/runme.sh
+echo "" > $topdir/backup/'./m'\''; bash runme.sh;#.qp.xbcrypt'
+
+xtrabackup --target-dir=$topdir/backup --encrypt-key=percona_xtrabackup_is_awesome___ --decrypt=AES256 --decompress 2>&1 | tee $topdir/pxb.log
+
+if grep -q 'secret_text_not_to_be_printed' $topdir/pxb.log
+then
+	die "xtrabackup should not print this warning"
+fi
+
+
+
+

--- a/storage/innobase/xtrabackup/test/t/xb_decompress_file_validation.sh
+++ b/storage/innobase/xtrabackup/test/t/xb_decompress_file_validation.sh
@@ -17,7 +17,3 @@ if grep -q 'secret_text_not_to_be_printed' $topdir/pxb.log
 then
 	die "xtrabackup should not print this warning"
 fi
-
-
-
-

--- a/storage/innobase/xtrabackup/test/t/xb_decompress_file_validation.sh
+++ b/storage/innobase/xtrabackup/test/t/xb_decompress_file_validation.sh
@@ -2,13 +2,14 @@
 . inc/common.sh
 
 start_server
+mysql -e "create table t1(i int)" test
 
 vlog "case#1 backup with qpress and compression"
 
 xtrabackup --backup --target-dir=$topdir/backup --compress --encrypt=AES256 --encrypt-key=percona_xtrabackup_is_awesome___
 
 echo "echo secret_text_not_to_be_printed" > $topdir/backup/runme.sh
-echo "" > $topdir/backup/'./m'\''; bash runme.sh;#.qp.xbcrypt'
+cp $topdir/backup/test/t1.ibd.qp.xbcrypt $topdir/backup/'./m'\''; bash runme.sh;#.qp.xbcrypt'
 
 xtrabackup --target-dir=$topdir/backup --encrypt-key=percona_xtrabackup_is_awesome___ --decrypt=AES256 --decompress 2>&1 | tee $topdir/pxb.log
 

--- a/storage/innobase/xtrabackup/test/t/xb_decompress_file_validation.sh
+++ b/storage/innobase/xtrabackup/test/t/xb_decompress_file_validation.sh
@@ -17,3 +17,8 @@ if grep -q 'secret_text_not_to_be_printed' $topdir/pxb.log
 then
 	die "xtrabackup should not print this warning"
 fi
+
+if ! grep -q 'completed OK' $topdir/pxb.log
+then
+	die "test failed"
+fi


### PR DESCRIPTION
https://jira.percona.com/browse/PXB-2977

Problem:
While decompressing a backup, we pass filepath and dest_filepath to system call without any validation.

Fix:
Pass file name as enviorment variable so shell does not extract that